### PR TITLE
Remove expired credentials before writing new STS credentials

### DIFF
--- a/lib/aws_assume_role/store/keyring.rb
+++ b/lib/aws_assume_role/store/keyring.rb
@@ -52,6 +52,7 @@ module AwsAssumeRole::Store::Keyring
         credentials_to_persist = Serialization.credentials_to_hash(credentials)
         credentials_to_persist[:expiration] = expiration if expiration
         semaphore.synchronize do
+            keyring(backend).delete_password(KEYRING_KEY, id)
             keyring(backend).set_password(KEYRING_KEY, id, credentials_to_persist.to_json)
         end
     end


### PR DESCRIPTION
The keychain backend throws KeychainDuplicateItemError silently (returning true)
when the call to set_password is made with an existing service/username pair.
This prevents aws-assume-role from overwriting expired credentials in the OS X
keychain (all calls go via STS to get new credentials).

This change removes any existing "password" from the keychain before writing
anything new.