### PR TITLE
0.2.1 - Make compatible with hiera-yaml by reducing constraint on highline

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,9 @@ Metrics/PerceivedComplexity:
 Style/IndentationWidth:
     Width: 4
 
+Style/IndentHeredoc:
+    Enabled: false
+
 Style/TrailingCommaInArguments:
     EnforcedStyleForMultiline: comma
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.1
+* Loosen requirement on highline to improve compatibility with Puppet tools (@randomvariable)
+
 ## 0.2.0
 
 * Add support for Yubikey as a source for MFA (@davbo)

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ begin
 rescue LoadError # rubocop:disable Lint/HandleExceptions
 end
 
-task :test => [:no_pry, :rubocop, :spec] # rubocop:disable Style/HashSyntax
+task :test => %i(no_pry rubocop spec) # rubocop:disable Style/HashSyntax
 
 task :no_pry do
     files = Dir.glob("**/**").reject { |x| x.match(/^spec|Gemfile|coverage|\.gemspec$|Rakefile/) || File.directory?(x) }

--- a/aws_assume_role.gemspec
+++ b/aws_assume_role.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 $LOAD_PATH << File.expand_path("../lib", __FILE__)
 require "aws_assume_role/version"
 Gem::Specification.new do |spec|

--- a/aws_assume_role.gemspec
+++ b/aws_assume_role.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
     spec.add_runtime_dependency "dry-types", "~> 0.9"
     spec.add_runtime_dependency "dry-validation", "~> 0.10"
     spec.add_runtime_dependency "gli", "~> 2.15"
-    spec.add_runtime_dependency "highline", "~> 1.7"
+    spec.add_runtime_dependency "highline", "~> 1.6"
     spec.add_runtime_dependency "i18n", "~> 0.7"
     spec.add_runtime_dependency "inifile", "~> 3.0"
     spec.add_runtime_dependency "launchy", "~> 2.4"

--- a/lib/aws_assume_role/cli/actions/console.rb
+++ b/lib/aws_assume_role/cli/actions/console.rb
@@ -20,7 +20,7 @@ class AwsAssumeRole::Cli::Actions::Console < AwsAssumeRole::Cli::Actions::Abstra
         required(:role_arn).maybe
         required(:role_session_name).maybe
         required(:duration_seconds).maybe
-        rule(role_specification: [:profile, :role_arn, :role_session_name, :duration_seconds]) do |p, r, s, d|
+        rule(role_specification: %i(profile role_arn role_session_name duration_seconds)) do |p, r, s, d|
             (p.filled? | p.empty? & r.filled?) & (r.filled? > s.filled? & d.filled?)
         end
     end

--- a/lib/aws_assume_role/cli/actions/run.rb
+++ b/lib/aws_assume_role/cli/actions/run.rb
@@ -12,7 +12,7 @@ class AwsAssumeRole::Cli::Actions::Run < AwsAssumeRole::Cli::Actions::AbstractAc
         required(:role_arn).maybe
         required(:role_session_name).maybe
         required(:duration_seconds).maybe
-        rule(role_specification: [:profile, :role_arn, :role_session_name, :duration_seconds]) do |p, r, s, d|
+        rule(role_specification: %i(profile role_arn role_session_name duration_seconds)) do |p, r, s, d|
             (p.filled? | p.empty? & r.filled?) & (r.filled? > s.filled? & d.filled?)
         end
     end

--- a/lib/aws_assume_role/cli/actions/set_environment.rb
+++ b/lib/aws_assume_role/cli/actions/set_environment.rb
@@ -30,7 +30,7 @@ class AwsAssumeRole::Cli::Actions::SetEnvironment < AwsAssumeRole::Cli::Actions:
         required(:role_arn).maybe { filled? > format?(ROLE_REGEX) }
         required(:role_session_name).maybe { filled? > format?(ROLE_SESSION_NAME_REGEX) }
         required(:duration_seconds).maybe
-        rule(role_specification: [:profile, :role_arn, :role_session_name, :duration_seconds]) do |p, r, s, d|
+        rule(role_specification: %i(profile role_arn role_session_name duration_seconds)) do |p, r, s, d|
             (p.filled? | p.empty? & r.filled?) & (r.filled? > s.filled? & d.filled?)
         end
     end

--- a/lib/aws_assume_role/cli/actions/test.rb
+++ b/lib/aws_assume_role/cli/actions/test.rb
@@ -11,7 +11,7 @@ class AwsAssumeRole::Cli::Actions::Test < AwsAssumeRole::Cli::Actions::AbstractA
         required(:role_arn).maybe
         required(:role_session_name).maybe
         required(:duration_seconds).maybe
-        rule(role_specification: [:profile, :role_arn, :role_session_name, :duration_seconds]) do |p, r, s, d|
+        rule(role_specification: %i(profile role_arn role_session_name duration_seconds)) do |p, r, s, d|
             (p.filled? | p.empty? & r.filled?) & (r.filled? > s.filled? & d.filled?)
         end
     end

--- a/lib/aws_assume_role/credentials/providers/assume_role_credentials.rb
+++ b/lib/aws_assume_role/credentials/providers/assume_role_credentials.rb
@@ -14,7 +14,7 @@ class AwsAssumeRole::Credentials::Providers::AssumeRoleCredentials
     #
     #
 
-    STS_KEYS = [:role_arn, :role_session_name, :policy, :duration_seconds, :external_id, :client, :credentials, :region].freeze
+    STS_KEYS = %i(role_arn role_session_name policy duration_seconds external_id client credentials region).freeze
 
     def initialize(options = {})
         client_opts = {}

--- a/lib/aws_assume_role/version.rb
+++ b/lib/aws_assume_role/version.rb
@@ -1,3 +1,3 @@
 module AwsAssumeRole
-    VERSION = "0.2.0".freeze
+    VERSION = "0.2.1".freeze
 end

--- a/spec/aws_assume_role/credentials/factories/default_chain_provider_spec.rb
+++ b/spec/aws_assume_role/credentials/factories/default_chain_provider_spec.rb
@@ -14,14 +14,14 @@ module AwsAssumeRole::Credentials::Factories
                    profile: nil,
                    instance_profile_credentials_timeout: 1,
                    instance_profile_credentials_retries: 0,
-                   resolve: [
-                       :access_key_id,
-                       :secret_access_key,
-                       :session_token,
-                       :profile,
-                       :instance_profile_credentials_timeout,
-                       :instance_profile_credentials_retries,
-                   ])
+                   resolve: %i(
+                       access_key_id
+                       secret_access_key
+                       session_token
+                       profile
+                       instance_profile_credentials_timeout
+                       instance_profile_credentials_retries
+                   ))
         end
 
         let(:chain) { DefaultChainProvider.new(config) }


### PR DESCRIPTION
Highline 1.6 is sufficient for aws-assume-role, and fixes breakage when included in a project with hiera-eyaml.