### PR TITLE
Apply new rules in Rubocop 0.48.1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ begin
 rescue LoadError # rubocop:disable Lint/HandleExceptions
 end
 
-task :test => %i(no_pry rubocop spec) # rubocop:disable Style/HashSyntax
+task :test => %i[no_pry rubocop spec] # rubocop:disable Style/HashSyntax
 
 task :no_pry do
     files = Dir.glob("**/**").reject { |x| x.match(/^spec|Gemfile|coverage|\.gemspec$|Rakefile/) || File.directory?(x) }

--- a/lib/aws_assume_role/cli/actions/console.rb
+++ b/lib/aws_assume_role/cli/actions/console.rb
@@ -20,7 +20,7 @@ class AwsAssumeRole::Cli::Actions::Console < AwsAssumeRole::Cli::Actions::Abstra
         required(:role_arn).maybe
         required(:role_session_name).maybe
         required(:duration_seconds).maybe
-        rule(role_specification: %i(profile role_arn role_session_name duration_seconds)) do |p, r, s, d|
+        rule(role_specification: %i[profile role_arn role_session_name duration_seconds]) do |p, r, s, d|
             (p.filled? | p.empty? & r.filled?) & (r.filled? > s.filled? & d.filled?)
         end
     end

--- a/lib/aws_assume_role/cli/actions/reset_environment.rb
+++ b/lib/aws_assume_role/cli/actions/reset_environment.rb
@@ -27,13 +27,13 @@ class AwsAssumeRole::Cli::Actions::ResetEnvironment < AwsAssumeRole::Cli::Action
     def act_on(config)
         shell_strings = SHELL_STRINGS[config.shell_type.to_sym]
         str = ""
-        %w(AWS_ACCESS_KEY_ID
+        %w[AWS_ACCESS_KEY_ID
            AWS_SECRET_ACCESS_KEY
            AWS_SESSION_TOKEN
            AWS_PROFILE
            AWS_ASSUME_ROLE_LOG_LEVEL
            GLI_DEBUG
-           AWS_ASSUME_ROLE_KEYRING_BACKEND).each do |key|
+           AWS_ASSUME_ROLE_KEYRING_BACKEND].each do |key|
             str << format(shell_strings[:env_command], key: key) if ENV.fetch(key, false)
         end
         str << "# #{pastel.yellow t(shell_strings.fetch(:footer, 'commands.set_environment.shells.others'))}"

--- a/lib/aws_assume_role/cli/actions/run.rb
+++ b/lib/aws_assume_role/cli/actions/run.rb
@@ -12,7 +12,7 @@ class AwsAssumeRole::Cli::Actions::Run < AwsAssumeRole::Cli::Actions::AbstractAc
         required(:role_arn).maybe
         required(:role_session_name).maybe
         required(:duration_seconds).maybe
-        rule(role_specification: %i(profile role_arn role_session_name duration_seconds)) do |p, r, s, d|
+        rule(role_specification: %i[profile role_arn role_session_name duration_seconds]) do |p, r, s, d|
             (p.filled? | p.empty? & r.filled?) & (r.filled? > s.filled? & d.filled?)
         end
     end

--- a/lib/aws_assume_role/cli/actions/set_environment.rb
+++ b/lib/aws_assume_role/cli/actions/set_environment.rb
@@ -30,7 +30,7 @@ class AwsAssumeRole::Cli::Actions::SetEnvironment < AwsAssumeRole::Cli::Actions:
         required(:role_arn).maybe { filled? > format?(ROLE_REGEX) }
         required(:role_session_name).maybe { filled? > format?(ROLE_SESSION_NAME_REGEX) }
         required(:duration_seconds).maybe
-        rule(role_specification: %i(profile role_arn role_session_name duration_seconds)) do |p, r, s, d|
+        rule(role_specification: %i[profile role_arn role_session_name duration_seconds]) do |p, r, s, d|
             (p.filled? | p.empty? & r.filled?) & (r.filled? > s.filled? & d.filled?)
         end
     end

--- a/lib/aws_assume_role/cli/actions/test.rb
+++ b/lib/aws_assume_role/cli/actions/test.rb
@@ -11,7 +11,7 @@ class AwsAssumeRole::Cli::Actions::Test < AwsAssumeRole::Cli::Actions::AbstractA
         required(:role_arn).maybe
         required(:role_session_name).maybe
         required(:duration_seconds).maybe
-        rule(role_specification: %i(profile role_arn role_session_name duration_seconds)) do |p, r, s, d|
+        rule(role_specification: %i[profile role_arn role_session_name duration_seconds]) do |p, r, s, d|
             (p.filled? | p.empty? & r.filled?) & (r.filled? > s.filled? & d.filled?)
         end
     end

--- a/lib/aws_assume_role/credentials/factories/environment.rb
+++ b/lib/aws_assume_role/credentials/factories/environment.rb
@@ -5,11 +5,11 @@ class AwsAssumeRole::Credentials::Factories::Environment < AwsAssumeRole::Creden
     priority 10
 
     def initialize(_options, **)
-        key =    %w(AWS_ACCESS_KEY_ID AMAZON_ACCESS_KEY_ID AWS_ACCESS_KEY)
-        secret = %w(AWS_SECRET_ACCESS_KEY AMAZON_SECRET_ACCESS_KEY AWS_SECRET_KEY)
-        token =  %w(AWS_SESSION_TOKEN AMAZON_SESSION_TOKEN)
-        region = %w(AWS_DEFAULT_REGION)
-        profile = %w(AWS_PROFILE)
+        key =    %w[AWS_ACCESS_KEY_ID AMAZON_ACCESS_KEY_ID AWS_ACCESS_KEY]
+        secret = %w[AWS_SECRET_ACCESS_KEY AMAZON_SECRET_ACCESS_KEY AWS_SECRET_KEY]
+        token =  %w[AWS_SESSION_TOKEN AMAZON_SESSION_TOKEN]
+        region = %w[AWS_DEFAULT_REGION]
+        profile = %w[AWS_PROFILE]
         @credentials = Aws::Credentials.new(envar(key), envar(secret), envar(token))
         @region = envar(region)
         @profile = envar(profile)

--- a/lib/aws_assume_role/credentials/providers/assume_role_credentials.rb
+++ b/lib/aws_assume_role/credentials/providers/assume_role_credentials.rb
@@ -14,7 +14,7 @@ class AwsAssumeRole::Credentials::Providers::AssumeRoleCredentials
     #
     #
 
-    STS_KEYS = %i(role_arn role_session_name policy duration_seconds external_id client credentials region).freeze
+    STS_KEYS = %i[role_arn role_session_name policy duration_seconds external_id client credentials region].freeze
 
     def initialize(options = {})
         client_opts = {}

--- a/spec/aws_assume_role/credentials/factories/default_chain_provider_spec.rb
+++ b/spec/aws_assume_role/credentials/factories/default_chain_provider_spec.rb
@@ -14,14 +14,14 @@ module AwsAssumeRole::Credentials::Factories
                    profile: nil,
                    instance_profile_credentials_timeout: 1,
                    instance_profile_credentials_retries: 0,
-                   resolve: %i(
+                   resolve: %i[
                        access_key_id
                        secret_access_key
                        session_token
                        profile
                        instance_profile_credentials_timeout
                        instance_profile_credentials_retries
-                   ))
+                   ])
         end
 
         let(:chain) { DefaultChainProvider.new(config) }


### PR DESCRIPTION
In the time between authoring the last PR, it passing on Travis and merging, a new version of Rubocop came out and it failed the Travis build. :-1: 