### PR TITLE
Add Yubikey OATH support to default chain provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+* Add Yubikey OATH support to the default chain provider (@randomvariable)
+
+
 ## 0.2.1
 * Loosen requirement on highline to improve compatibility with Puppet tools (@randomvariable)
 

--- a/lib/aws_assume_role/credentials/factories/default_chain_provider.rb
+++ b/lib/aws_assume_role/credentials/factories/default_chain_provider.rb
@@ -16,24 +16,25 @@ class AwsAssumeRole::Credentials::Factories::DefaultChainProvider < Dry::Struct
 
     attribute :access_key_id, Dry::Types["strict.string"].optional
     attribute :credentials, Dry::Types["object"].optional
-    attribute :secret_access_key, Dry::Types["strict.string"].optional
-    attribute :session_token, Dry::Types["strict.string"].optional
     attribute :duration_seconds, Dry::Types["coercible.int"].optional
     attribute :external_id, Dry::Types["strict.string"].optional
-    attribute :persist_session, Dry::Types["strict.bool"].default(true)
+    attribute :instance_profile_credentials_retries, Dry::Types["strict.int"].default(0)
+    attribute :instance_profile_credentials_timeout, Dry::Types["coercible.float"].default(1.0)
+    attribute :mfa_serial, Dry::Types["strict.string"].optional
+    attribute :no_profile, Dry::Types["strict.bool"].default(false)
     attribute :path, Dry::Types["strict.string"].optional
-    attribute :profile, Dry::Types["strict.string"].optional
+    attribute :persist_session, Dry::Types["strict.bool"].default(true)
     attribute :profile_name, Dry::Types["strict.string"].optional
+    attribute :profile, Dry::Types["strict.string"].optional
     attribute :region, Dry::Types["strict.string"].optional
     attribute :role_arn, Dry::Types["strict.string"].optional
     attribute :role_session_name, Dry::Types["strict.string"].optional
+    attribute :secret_access_key, Dry::Types["strict.string"].optional
     attribute :serial_number, Dry::Types["strict.string"].optional
-    attribute :mfa_serial, Dry::Types["strict.string"].optional
-    attribute :use_mfa, Dry::Types["strict.bool"].default(false)
-    attribute :no_profile, Dry::Types["strict.bool"].default(false)
+    attribute :session_token, Dry::Types["strict.string"].optional
     attribute :source_profile, Dry::Types["strict.string"].optional
-    attribute :instance_profile_credentials_retries, Dry::Types["strict.int"].default(0)
-    attribute :instance_profile_credentials_timeout, Dry::Types["coercible.float"].default(1.0)
+    attribute :use_mfa, Dry::Types["strict.bool"].default(false)
+    attribute :yubikey_oath_name, Dry::Types["strict.string"].optional
 
     def self.new(options)
         if options.respond_to? :resolve

--- a/lib/aws_assume_role/version.rb
+++ b/lib/aws_assume_role/version.rb
@@ -1,3 +1,3 @@
 module AwsAssumeRole
-    VERSION = "0.2.1".freeze
+    VERSION = "0.2.2".freeze
 end


### PR DESCRIPTION
Small change to allow Yubikeys to be used in the credential selection chain.