### PR TITLE
Bugfix: assign credentials to instance variable

### DIFF
--- a/lib/aws_assume_role/credentials/providers/mfa_session_credentials.rb
+++ b/lib/aws_assume_role/credentials/providers/mfa_session_credentials.rb
@@ -30,7 +30,7 @@ class AwsAssumeRole::Credentials::Providers::MfaSessionCredentials < Dry::Struct
 
     def initialize(options)
         options.each { |key, value| instance_variable_set("@#{key}", value) }
-        @permanent_credentials ||= credentials
+        @permanent_credentials ||= @credentials
         @credentials = nil
         @serial_number = resolve_serial_number(serial_number)
         AwsAssumeRole::Vendored::Aws::RefreshingCredentials.instance_method(:initialize).bind(self).call(options)


### PR DESCRIPTION
The release of `v0.4` of `dry-struct` seems to have introduced a bug:

```
➜  ~ aws-assume-role console -p my-profile
No credentials found!
error: exit
```

The issue seems to be that `credentials` is set as an instance variable, but not explicitly used as one.