### PR TITLE
18: env set fix frozen string error

### DIFF
--- a/lib/aws_assume_role/cli/actions/set_environment.rb
+++ b/lib/aws_assume_role/cli/actions/set_environment.rb
@@ -40,7 +40,7 @@ class AwsAssumeRole::Cli::Actions::SetEnvironment < AwsAssumeRole::Cli::Actions:
     def act_on(config)
         credentials = try_for_credentials config.to_h
         shell_strings = SHELL_STRINGS[config.shell_type.to_sym]
-        str = ""
+        str = String.new("")
         [
             [:access_key_id, "AWS_ACCESS_KEY_ID"],
             [:secret_access_key, "AWS_SECRET_ACCESS_KEY"],


### PR DESCRIPTION
Fixes #18.

It seems when using `<<` the initial variable is modified, and for some reason when set via `=''` or `=""` it is seen as a frozen string. Setting it to the new `String.new` variable resolves this issue.