### PR TITLE
Highline ask on stderr for use in `eval`

### DIFF
--- a/lib/aws_assume_role/ui.rb
+++ b/lib/aws_assume_role/ui.rb
@@ -19,7 +19,7 @@ module AwsAssumeRole::Ui
     end
 
     def input
-        @input ||= HighLine.new
+        @input ||= HighLine.new($stdin, $stderr)
     end
 
     def validation_errors_to_s(result)


### PR DESCRIPTION
Hi!

I've noticed when using `aws-assume-role environment set -p <<my-env>>` that requests for the user such as `Credentials have expired, please provide another MFA` are output to STDOUT. This is great except for when you use `eval` to set those values in your shell. 

This PR alters the Highline initialisation to use STDERR as it's output stream allowing the user to see the message / request from `aws-assume-role`. 

Any feedback greatly appreciated.

Thanks,

Tim Birkett. 