### PR TITLE
Fix frozen string issue in environment reset

### DIFF
--- a/lib/aws_assume_role/cli/actions/reset_environment.rb
+++ b/lib/aws_assume_role/cli/actions/reset_environment.rb
@@ -28,7 +28,7 @@ class AwsAssumeRole::Cli::Actions::ResetEnvironment < AwsAssumeRole::Cli::Action
 
     def act_on(config)
         shell_strings = SHELL_STRINGS[config.shell_type.to_sym]
-        str = ""
+        str = String.new("")
         %w[AWS_ACCESS_KEY_ID
            AWS_SECRET_ACCESS_KEY
            AWS_SESSION_TOKEN


### PR DESCRIPTION
Hey, 

There's another instance of: `error can't modify frozen string` in `aws-assume-role environment reset`.

This PR fixes that in the same way as a previous commit: https://github.com/scalefactory/aws-assume-role/commit/9dcc1e2876e5fb85a0e2acc3eaf72b606a27414f#diff-d8c9af6d755445327397b9c265e859c3

Kind Regards,

Tim Birkett.