### PR TITLE
Determine platform dependencies at install time

### DIFF
--- a/aws_assume_role.gemspec
+++ b/aws_assume_role.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
     }
     spec.bindir        = "bin"
     spec.executables   = spec.files.grep(%r{^bin/aws}) { |f| File.basename(f) }
+    spec.extensions    = "ext/mkrf_conf.rb"
     spec.require_paths = ["lib"]
 
     spec.add_runtime_dependency "activesupport", "~> 4.2"
@@ -43,11 +44,4 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency "yard", "~> 0.9"
     spec.add_development_dependency "simplecov", "~> 0.13"
     spec.add_development_dependency "webmock", "~> 2.3"
-
-    case Gem::Platform.local.os
-    when "linux"
-        spec.add_dependency "gir_ffi-gnome_keyring", "~> 0.0", ">= 0.0.3"
-    when "darwin"
-        spec.add_dependency "ruby-keychain", "~> 0.3", ">= 0.3.2"
-    end
 end

--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -1,0 +1,25 @@
+require "rubygems"
+require "rubygems/command"
+require "rubygems/dependency_installer"
+begin
+    Gem::Command.build_args = ARGV
+rescue NoMethodError # rubocop:disable Lint/HandleExceptions
+end
+
+installer = Gem::DependencyInstaller.new
+
+begin
+    case Gem::Platform.local.os
+    when "linux"
+        installer.install "gir_ffi-gnome_keyring", Gem::Requirement.new("~> 0.0", ">= 0.0.3")
+    when "darwin"
+        installer.install "ruby-keychain", Gem::Requirement.new("~> 0.3", ">= 0.3.2")
+    end
+rescue => e # rubocop:disable Lint/RescueWithoutErrorClass
+    puts e.backtrace
+    exit(1)
+end
+
+f = File.open(File.join(File.dirname(__FILE__), "Rakefile"), "w") # create dummy rakefile to indicate success
+f.write("task :default\n")
+f.close


### PR DESCRIPTION
Gemspec is evaluated and the resultant data is cached at gem build time.
Instead move the installation of the dependencies to install time within a native extension rake file.