### PR TITLE
Calculate single token

### DIFF
--- a/lib/aws_assume_role/credentials/providers/mfa_session_credentials.rb
+++ b/lib/aws_assume_role/credentials/providers/mfa_session_credentials.rb
@@ -67,8 +67,7 @@ class AwsAssumeRole::Credentials::Providers::MfaSessionCredentials < Dry::Struct
         raise "Yubikey not found" unless context.readers.length == 1
         reader_name = context.readers.first
         card = Smartcard::PCSC::Card.new(context, reader_name, :shared)
-        codes = YubiOATH.new(card).calculate_all(timestamp: Time.now)
-        codes.fetch(BinData::String.new(@yubikey_oath_name))
+        YubiOATH.new(card).calculate(name: @yubikey_oath_name, timestamp: Time.now)
     end
 
     def refresh_using_mfa


### PR DESCRIPTION
[YubiOATH](https://github.com/jamesottaway/yubioath) does not always return every token in [calculate_all](https://github.com/jamesottaway/yubioath/blob/master/lib/yubioath/calculate_all.rb). This change will request a single token with [calculate](https://github.com/jamesottaway/yubioath/blob/master/lib/yubioath/calculate.rb).

Resolves: scalefactory/aws-assume-role#30