### PR TITLE
make authors list rubocop-compatible

### DIFF
--- a/aws_assume_role.gemspec
+++ b/aws_assume_role.gemspec
@@ -8,7 +8,8 @@ PLATFORM = ENV.fetch("PLATFORM", Gem::Platform.local.os)
 Gem::Specification.new do |spec|
     spec.name          = "aws_assume_role"
     spec.version       = AwsAssumeRole::VERSION
-    spec.authors       = ["Jon Topper", "Jack Thomas", "Naadir Jeewa", "David King", "Tim Bannister", "Phil Potter", "Tom Haynes", "Alan Ivey"]
+    spec.authors       = ["Jon Topper", "Jack Thomas", "Naadir Jeewa", "David King",
+                          "Tim Bannister", "Phil Potter", "Tom Haynes", "Alan Ivey"]
     spec.email         = ["jon@scalefactory.com", "jack@scalefactory.com", "naadir@scalefactory.com", "tim@scalefactory.com"]
 
     spec.description   = "Used to fetch multiple AWS Role Credential "\


### PR DESCRIPTION
rubocop (and, hence, travis) is failing because this line is too long