### PR TITLE
Dry types dropped support for int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.1
+* Fix deprecation of int in dry-types to use integer
+
 ## 1.2.0
 * Support latest version of `dry-*` gems
 * Requires ruby 2.3

--- a/lib/aws_assume_role/credentials/factories/abstract_factory.rb
+++ b/lib/aws_assume_role/credentials/factories/abstract_factory.rb
@@ -22,7 +22,7 @@ class AwsAssumeRole::Credentials::Factories::AbstractFactory
     end
 
     def self.priority(i)
-        @priority = Types::Strict::Int[i]
+        @priority = Types::Strict::Integer[i]
         register_if_complete
     end
 

--- a/lib/aws_assume_role/credentials/factories/default_chain_provider.rb
+++ b/lib/aws_assume_role/credentials/factories/default_chain_provider.rb
@@ -19,9 +19,9 @@ class AwsAssumeRole::Credentials::Factories::DefaultChainProvider < Dry::Struct
 
     attribute :access_key_id, Dry::Types["strict.string"].optional
     attribute :credentials, Dry::Types["object"].optional
-    attribute :duration_seconds, Dry::Types["coercible.int"].optional
+    attribute :duration_seconds, Dry::Types["coercible.integer"].optional
     attribute :external_id, Dry::Types["strict.string"].optional
-    attribute :instance_profile_credentials_retries, Dry::Types["strict.int"].default(0)
+    attribute :instance_profile_credentials_retries, Dry::Types["strict.integer"].default(0)
     attribute :instance_profile_credentials_timeout, Dry::Types["coercible.float"].default(1.0)
     attribute :mfa_serial, Dry::Types["strict.string"].optional
     attribute :no_profile, Dry::Types["strict.bool"].default(false)

--- a/lib/aws_assume_role/credentials/factories/repository.rb
+++ b/lib/aws_assume_role/credentials/factories/repository.rb
@@ -7,7 +7,7 @@ class AwsAssumeRole::Credentials::Factories::Repository
     include AwsAssumeRole::Credentials::Factories
 
     SubFactoryRepositoryType = Types::Hash.schema(
-        Types::Coercible::Int => Types::Strict::Array.meta(omittable: true),
+        Types::Coercible::Integer => Types::Strict::Array.meta(omittable: true),
     )
 
     FactoryRepositoryType = Types::Hash.schema(

--- a/lib/aws_assume_role/credentials/providers/mfa_session_credentials.rb
+++ b/lib/aws_assume_role/credentials/providers/mfa_session_credentials.rb
@@ -30,7 +30,7 @@ class AwsAssumeRole::Credentials::Providers::MfaSessionCredentials < Dry::Struct
     attribute :persist_session, (Dry::Types["strict.bool"]
         .default(true)
         .constructor { |v| v.nil? ? Dry::Types::Undefined : v })
-    attribute :duration_seconds, (Dry::Types["coercible.int"]
+    attribute :duration_seconds, (Dry::Types["coercible.integer"]
         .default(3600)
         .constructor { |v| v.nil? ? Dry::Types::Undefined : v })
     attribute :region, AwsAssumeRole::Types::Region

--- a/lib/aws_assume_role/profile_configuration.rb
+++ b/lib/aws_assume_role/profile_configuration.rb
@@ -11,7 +11,7 @@ class AwsAssumeRole::ProfileConfiguration < Dry::Struct
     attribute :credentials, Dry::Types["object"].optional
     attribute :secret_access_key, Dry::Types["strict.string"].optional
     attribute :session_token, Dry::Types["strict.string"].optional
-    attribute :duration_seconds, Dry::Types["coercible.int"].optional
+    attribute :duration_seconds, Dry::Types["coercible.integer"].optional
     attribute :external_id, Dry::Types["strict.string"].optional
     attribute :path, Dry::Types["strict.string"].optional
     attribute :persist_session, Dry::Types["strict.bool"].optional.default(true)
@@ -27,7 +27,7 @@ class AwsAssumeRole::ProfileConfiguration < Dry::Struct
     attribute :shell_type, Dry::Types["strict.string"].optional
     attribute :source_profile, Dry::Types["strict.string"].optional
     attribute :args, Dry::Types["strict.array"].optional.default([])
-    attribute :instance_profile_credentials_retries, Dry::Types["strict.int"].default(0)
+    attribute :instance_profile_credentials_retries, Dry::Types["strict.integer"].default(0)
     attribute :instance_profile_credentials_timeout, Dry::Types["coercible.float"].default(1.0)
 
     attr_writer :credentials

--- a/lib/aws_assume_role/runner.rb
+++ b/lib/aws_assume_role/runner.rb
@@ -7,7 +7,7 @@ class AwsAssumeRole::Runner < Dry::Struct
     include AwsAssumeRole::Logging
     attribute :command, Dry::Types["coercible.array"].of(Dry::Types["strict.string"]).default([])
     attribute :exit_on_error, Dry::Types["strict.bool"].default(true)
-    attribute :expected_exit_code, Dry::Types["strict.int"].default(0)
+    attribute :expected_exit_code, Dry::Types["strict.integer"].default(0)
     attribute :environment, Dry::Types["strict.hash"].default({})
     attribute :credentials, Dry::Types["object"].optional
 

--- a/lib/aws_assume_role/version.rb
+++ b/lib/aws_assume_role/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AwsAssumeRole
-    VERSION = "1.2.0".freeze
+    VERSION = "1.2.1".freeze
 end


### PR DESCRIPTION
Changed to integer. this error only surfaced when interacting with aws_assume_role via the library interface, not cli