### PR TITLE
Fix the run subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bundle/
+*~
 *.swp
 vendor/
 pkg/

--- a/aws_assume_role.gemspec
+++ b/aws_assume_role.gemspec
@@ -6,12 +6,26 @@ require "aws_assume_role/version"
 PLATFORM = ENV.fetch("PLATFORM", Gem::Platform.local.os)
 
 Gem::Specification.new do |spec|
-    spec.name          = "aws_assume_role"
-    spec.version       = AwsAssumeRole::VERSION
-    spec.authors       = ["Jon Topper", "Jack Thomas", "Naadir Jeewa", "David King",
-                          "Tim Bannister", "Phil Potter", "Tom Haynes", "Alan Ivey",
-                          "David O'Rourke"]
-    spec.email         = ["jon@scalefactory.com", "jack@scalefactory.com", "naadir@scalefactory.com", "tim@scalefactory.com", "david@scalefactory.com"]
+    spec.name    = "aws_assume_role"
+    spec.version = AwsAssumeRole::VERSION
+    spec.authors = [
+        "Jon Topper",
+        "Jack Thomas",
+        "Naadir Jeewa",
+        "David King",
+        "Tim Bannister",
+        "Phil Potter",
+        "Tom Haynes",
+        "Alan Ivey",
+        "David O'Rourke",
+    ]
+    spec.email = [
+        "jon@scalefactory.com",
+        "jack@scalefactory.com",
+        "naadir@scalefactory.com",
+        "tim@scalefactory.com",
+        "david@scalefactory.com",
+    ]
 
     spec.description   = "Used to fetch multiple AWS Role Credential "\
                          "Keys using different Session Keys "\

--- a/aws_assume_role.gemspec
+++ b/aws_assume_role.gemspec
@@ -9,8 +9,9 @@ Gem::Specification.new do |spec|
     spec.name          = "aws_assume_role"
     spec.version       = AwsAssumeRole::VERSION
     spec.authors       = ["Jon Topper", "Jack Thomas", "Naadir Jeewa", "David King",
-                          "Tim Bannister", "Phil Potter", "Tom Haynes", "Alan Ivey"]
-    spec.email         = ["jon@scalefactory.com", "jack@scalefactory.com", "naadir@scalefactory.com", "tim@scalefactory.com"]
+                          "Tim Bannister", "Phil Potter", "Tom Haynes", "Alan Ivey",
+                          "David O'Rourke"]
+    spec.email         = ["jon@scalefactory.com", "jack@scalefactory.com", "naadir@scalefactory.com", "tim@scalefactory.com", "david@scalefactory.com"]
 
     spec.description   = "Used to fetch multiple AWS Role Credential "\
                          "Keys using different Session Keys "\

--- a/lib/aws_assume_role/runner.rb
+++ b/lib/aws_assume_role/runner.rb
@@ -17,7 +17,7 @@ class AwsAssumeRole::Runner < Dry::Struct
         super(options)
         command_to_exec = command.map(&:shellescape).join(" ")
         process_credentials unless credentials.blank?
-        system environment, command_to_exec
+        system @environment, command_to_exec
         exit_status = $CHILD_STATUS.exitstatus
         process_error(exit_status) if exit_status != expected_exit_code
     end


### PR DESCRIPTION
Fixes #38 

This PR fixes the `run` subcommand by having it use the correct environment variables when executing the command.